### PR TITLE
Support tox 3.5 and test with tox 3.5, latest and git master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 
 RUN dnf -y install --setopt=install_weak_deps=false --setopt=tsflags=nodocs \
     --setopt=deltarpm=false --allowerasing --best --disablerepo=\*modular \
-    tox python36 python37 python38 && \
+    tox python36 python37 python38 git-core && \
     dnf -y --setopt=install_weak_deps=false --setopt=tsflags=nodocs --best\
     --setopt=deltarpm=false --allowerasing --disablerepo=\*modular update && \
     dnf clean all

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     entry_points={"tox": ["current-env = tox_current_env.hooks"]},
-    install_requires=["tox>=3.8.1"],
+    install_requires=["tox>=3.5"],
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
-envlist = py36,py37,py38
+envlist = {py36,py37,py38}-tox{35,release,master}
 
 [testenv]
-deps = pytest
+deps=
+    pytest
+    tox35: tox >=3.5,<3.6
+    toxrelease: tox
+    toxmaster: git+https://github.com/tox-dev/tox.git@master
 commands =
     pytest -v {posargs} tests


### PR DESCRIPTION
Inspired by https://github.com/pytest-dev/pluggy/blob/master/tox.ini

Fedora 30 has tox 3.5.