### PR TITLE
Add --print-deps-to-file option for easier parsable dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,11 @@ The ``tox-current-env`` plugin adds two options:
    An attempt to run this with a Python version that doesn't match will fail
    (if ``tox`` is invoked from an Python 3.7 environment, any non 3.7 testenv will fail).
 
-``tox --print-deps-only``
+``tox --print-deps-only`` / ``--print-deps-to-file``
     Instead of running any ``commands``,
-    simply prints the declared dependencies in ``deps`` to the standard output.
+    simply prints the declared dependencies in ``deps`` to the standard output or specified file.
     This is useful for preparing the current environment for the above.
+    ``--print-deps-to-file`` will override the file, if it already exists.
 
 Invoking ``tox`` without any of the above options should behave as regular ``tox`` invocation without this plugin.
 Any deviation from this behavior is considered a bug.

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The ``tox-current-env`` plugin adds two options:
     Instead of running any ``commands``,
     simply prints the declared dependencies in ``deps`` to the standard output or specified file.
     This is useful for preparing the current environment for the above.
-    ``--print-deps-to-file`` will override the file, if it already exists.
+    ``--print-deps-to-file`` will overwrite the file if it already exists.
 
 Invoking ``tox`` without any of the above options should behave as regular ``tox`` invocation without this plugin.
 Any deviation from this behavior is considered a bug.

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -18,7 +18,7 @@ def tox_addoption(parser):
         action="store_true",
         dest="print_deps_only",
         default=False,
-        help="Don't run tests, only print the dependencies",
+        help="Don't run tests, only print the dependencies to stdout",
     )
     parser.add_argument(
         "--print-deps-to-file",
@@ -33,6 +33,10 @@ def tox_addoption(parser):
 @tox.hookimpl
 def tox_configure(config):
     """Stores options in the config. Makes all commands external and skips sdist"""
+    if config.option.print_deps_only and config.option.print_deps_path:
+        raise tox.exception.ConfigError(
+            "--print-deps-only cannot be used together with --print-deps-to-file"
+        )
     if config.option.print_deps_path is not None:
         config.option.print_deps_only = True
         with open(config.option.print_deps_path, "w", encoding="utf-8") as f:

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -26,7 +26,7 @@ def tox_addoption(parser):
         dest="print_deps_path",
         metavar="PATH",
         default=None,
-        help="Like --print-deps-only, but to a file (overrides the file)",
+        help="Like --print-deps-only, but to a file. Overwrites the file if it exists.",
     )
 
 

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -20,11 +20,23 @@ def tox_addoption(parser):
         default=False,
         help="Don't run tests, only print the dependencies",
     )
+    parser.add_argument(
+        "--print-deps-to-file",
+        action="store",
+        dest="print_deps_path",
+        metavar="PATH",
+        default=None,
+        help="Like --print-deps-only, but to a file (overrides the file)",
+    )
 
 
 @tox.hookimpl
 def tox_configure(config):
     """Stores options in the config. Makes all commands external and skips sdist"""
+    if config.option.print_deps_path is not None:
+        config.option.print_deps_only = True
+        with open(config.option.print_deps_path, "w", encoding="utf-8") as f:
+            f.write("")
     if config.option.current_env or config.option.print_deps_only:
         config.skipsdist = True
         for testenv in config.envconfigs:
@@ -136,7 +148,10 @@ def tox_runtest(venv, redirect):
     """If --print-deps-only, prints deps instead of running tests"""
     config = venv.envconfig.config
     unsupported_raise(config, venv)
+    if config.option.print_deps_path is not None:
+        with open(config.option.print_deps_path, "a", encoding="utf-8") as f:
+            print(*venv.get_resolved_dependencies(), sep="\n", file=f)
+        return True
     if config.option.print_deps_only:
-        for dependency in venv.get_resolved_dependencies():
-            print(dependency)
+        print(*venv.get_resolved_dependencies(), sep="\n")
         return True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,6 +154,19 @@ def test_allenvs_print_deps_to_existing_file(tmp_path):
     assert "py" in lines
 
 
+def test_print_deps_only_print_deps_to_file_are_mutually_exclusive():
+    result = tox(
+        "-e",
+        NATIVE_TOXENV,
+        "--print-deps-only",
+        "--print-deps-to-file",
+        "foobar",
+        check=False,
+    )
+    assert result.returncode > 0
+    assert "cannot be used together" in result.stderr
+
+
 @needs_py3678
 def test_regular_run():
     result = tox()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -113,6 +113,47 @@ def test_allenvs_print_deps_only():
     assert result.stdout == expected
 
 
+@pytest.mark.parametrize("toxenv", ["py36", "py37", "py38"])
+def test_print_deps_to_file(toxenv, tmp_path):
+    depspath = tmp_path / "deps"
+    result = tox("-e", toxenv, "--print-deps-to-file", str(depspath))
+    assert depspath.read_text().splitlines() == ["six", "py"]
+    expected = textwrap.dedent(
+        f"""
+        ___________________________________ summary ____________________________________
+          {toxenv}: commands succeeded
+          congratulations :)
+        """
+    ).lstrip()
+    assert result.stdout == expected
+
+
+def test_allenvs_print_deps_to_file(tmp_path):
+    depspath = tmp_path / "deps"
+    result = tox("--print-deps-to-file", str(depspath))
+    assert depspath.read_text().splitlines() == ["six", "py"] * 3
+    expected = textwrap.dedent(
+        """
+        ___________________________________ summary ____________________________________
+          py36: commands succeeded
+          py37: commands succeeded
+          py38: commands succeeded
+          congratulations :)
+        """
+    ).lstrip()
+    assert result.stdout == expected
+
+
+def test_allenvs_print_deps_to_existing_file(tmp_path):
+    depspath = tmp_path / "deps"
+    depspath.write_text("nada")
+    result = tox("--print-deps-to-file", str(depspath))
+    lines = depspath.read_text().splitlines()
+    assert "nada" not in lines
+    assert "six" in lines
+    assert "py" in lines
+
+
 @needs_py3678
 def test_regular_run():
     result = tox()


### PR DESCRIPTION
Fixes https://github.com/fedora-python/tox-current-env/issues/13