### PR TITLE
Clean fake venvs after --current-env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,8 +163,9 @@ and regular ``tox`` runs (without the flag).
 If you ever need to do this, use tox's ``--recreate/-r`` flag to clear the cache.
 
 The plugin should abort with a meaningful error message if this is detected,
-but in some cases (such as running ``tox --current-env``, uninstalling the
-plugin, and running ``tox``), you will get undefined results
+but in some corner cases (such as running ``tox --current-env``,
+forcefully killing it before it finished, uninstalling the plugin,
+and running ``tox``), you will get undefined results
 (such as installing packages from PyPI into your current environment).
 
 Environment variables are not passed by default

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -59,13 +59,19 @@ def is_any_env(venv):
     return python
 
 
+def rm_venv(venv):
+    link = venv.envconfig.get_envpython()
+    shutil.rmtree(os.path.dirname(os.path.dirname(link)), ignore_errors=True)
+
+
 def unsupported_raise(config, venv):
     if config.option.recreate:
         return
     regular = not (config.option.current_env or config.option.print_deps_only)
     if regular and is_current_env_link(venv):
         raise tox.exception.ConfigError(
-            "Regular tox run after --current-env or --print-deps-only tox run is not supported without --recreate (-r)."
+            "Looks like previous --current-env or --print-deps-only tox run didn't finish the cleanup. "
+            "Run tox run with --recreate (-r) or manually remove the environment in .tox."
         )
     elif config.option.current_env and is_proper_venv(venv):
         raise tox.exception.ConfigError(
@@ -110,8 +116,7 @@ def tox_testenv_create(venv, action):
         os.symlink(target, link)
         return True
     else:
-        link = venv.envconfig.get_envpython()
-        shutil.rmtree(os.path.dirname(os.path.dirname(link)), ignore_errors=True)
+        rm_venv(venv)
         return None  # let tox handle the rest
 
 
@@ -140,3 +145,13 @@ def tox_runtest(venv, redirect):
         for dependency in venv.get_resolved_dependencies():
             print(dependency)
         return True
+
+
+@tox.hookimpl
+def tox_cleanup(session):
+    """Remove the fake virtualenv not to collide with regular tox
+    Collisions can happen anyway (when tox is killed forcefully before this happens)
+    Note that we don't remove real venvs, as recreating them is expensive"""
+    for venv in session.venv_dict.values():
+        if is_current_env_link(venv):
+            rm_venv(venv)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import textwrap
 
+from packaging import version
+
 import pytest
 
 
@@ -37,11 +39,17 @@ def is_available(python):
     return True
 
 
+TOX_VERSION = version.parse(tox("--version").stdout.split(" ")[0])
+
 needs_py3678 = pytest.mark.skipif(
     not is_available("python3.6")
     or not is_available("python3.7")
     or not is_available("python3.8"),
     reason="This test needs all of python3.6, python3.7 and python3.8 to be available in $PATH",
+)
+
+needs_tox38 = pytest.mark.skipif(
+    TOX_VERSION < version.parse("3.8"), reason="This test needs at least tox 3.8"
 )
 
 
@@ -141,6 +149,7 @@ def test_regular_run_native_toxenv():
         assert len(list(sitelib.glob(f"{pkg}-*.dist-info"))) == 1
 
 
+@needs_tox38
 def test_regular_after_current_is_supported():
     result = tox("-e", NATIVE_TOXENV, "--current-env")
     assert result.stdout.splitlines()[0] == NATIVE_EXECUTABLE
@@ -160,6 +169,7 @@ def test_regular_after_killed_current_is_not_supported():
     assert "--recreate" in result.stderr
 
 
+@needs_tox38
 def test_regular_after_first_deps_only_is_supported():
     result = tox("-e", NATIVE_TOXENV, "--print-deps-only")
     assert result.stdout.splitlines()[0] == "six"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -141,20 +141,32 @@ def test_regular_run_native_toxenv():
         assert len(list(sitelib.glob(f"{pkg}-*.dist-info"))) == 1
 
 
-def test_regular_after_current_is_not_supported():
+def test_regular_after_current_is_supported():
     result = tox("-e", NATIVE_TOXENV, "--current-env")
     assert result.stdout.splitlines()[0] == NATIVE_EXECUTABLE
+    result = tox("-e", NATIVE_TOXENV, prune=False)
+    assert f"/.tox/{NATIVE_TOXENV}/bin/python" in result.stdout
+    assert "--recreate" not in result.stderr
+
+
+def test_regular_after_killed_current_is_not_supported():
+    # fake broken tox run
+    shutil.rmtree(DOT_TOX, ignore_errors=True)
+    (DOT_TOX / NATIVE_TOXENV / "bin").mkdir(parents=True)
+    (DOT_TOX / NATIVE_TOXENV / "bin" / "python").symlink_to(NATIVE_EXECUTABLE)
+
     result = tox("-e", NATIVE_TOXENV, prune=False, check=False)
     assert result.returncode > 0
-    assert "not supported" in result.stderr
+    assert "--recreate" in result.stderr
 
 
-def test_regular_after_first_deps_only_is_not_supported():
+def test_regular_after_first_deps_only_is_supported():
     result = tox("-e", NATIVE_TOXENV, "--print-deps-only")
     assert result.stdout.splitlines()[0] == "six"
-    result = tox("-e", NATIVE_TOXENV, prune=False, check=False)
-    assert result.returncode > 0
-    assert "not supported" in result.stderr
+    result = tox("-e", NATIVE_TOXENV, prune=False)
+    lines = sorted(result.stdout.splitlines()[:1])
+    assert "--recreate" not in result.stderr
+    assert f"/.tox/{NATIVE_TOXENV}/bin/python" in lines[0]
 
     # check that "test" was not installed to current environment
     pip_freeze = subprocess.run(
@@ -171,6 +183,7 @@ def test_regular_recreate_after_current():
     result = tox("-re", NATIVE_TOXENV, prune=False)
     assert f"/.tox/{NATIVE_TOXENV}/bin/python" in result.stdout
     assert "not supported" not in result.stderr
+    assert "--recreate" not in result.stderr
 
 
 def test_current_after_regular_is_not_supported():

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = {py36,py37,py38}-tox{35,release,master}
 [testenv]
 deps=
     pytest
+    packaging
     tox35: tox >=3.5,<3.6
     toxrelease: tox
     toxmaster: git+https://github.com/tox-dev/tox.git@master


### PR DESCRIPTION
This makes it easier to run regular `tox` after `tox --current-env`, however not the other way around.

The documented caveat remains the same: Don't mix those without `-r`.

Partially fixes https://github.com/fedora-python/tox-current-env/issues/14