### PR TITLE
Avoid requiring admin rights on Windows

### DIFF
--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import sys
 import tox
 
@@ -134,7 +135,11 @@ def tox_testenv_create(venv, action):
         target = sys.executable
         rm_venv(venv)
         os.makedirs(os.path.dirname(link))
-        os.symlink(target, link)
+        if sys.platform == "win32":
+            # Avoid requiring admin rights on Windows
+            subprocess.check_call('mklink /J "%s" "%s"' % (link, target), shell=True)
+        else:
+            os.symlink(target, link)
         # prevent tox from creating the venv
         return True
     if not is_proper_venv(venv):

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -137,7 +137,7 @@ def tox_testenv_create(venv, action):
         os.makedirs(os.path.dirname(link))
         if sys.platform == "win32":
             # Avoid requiring admin rights on Windows
-            subprocess.check_call('mklink /J "{link}" "{target}"', shell=True)
+            subprocess.check_call(f'mklink /J "{link}" "{target}"', shell=True)
         else:
             os.symlink(target, link)
         # prevent tox from creating the venv

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -137,7 +137,7 @@ def tox_testenv_create(venv, action):
         os.makedirs(os.path.dirname(link))
         if sys.platform == "win32":
             # Avoid requiring admin rights on Windows
-            subprocess.check_call('mklink /J "%s" "%s"' % (link, target), shell=True)
+            subprocess.check_call('mklink /J "{link}" "{target}"', shell=True)
         else:
             os.symlink(target, link)
         # prevent tox from creating the venv


### PR DESCRIPTION
Thank you for this excellent plugin! ❤

This fixes an error on Windows (I'm on with Python 3.7) where the symlink cannot be created without admin rights.

Example:

```
$ tox -e formatting --current-env
formatting create: C:\Users\fredrik\code\repos\mylittleci\.tox\formatting
__________________________ summary __________________________
  formatting: commands succeeded
  congratulations :)
Traceback (most recent call last):
  File "C:\Users\fredrik\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\fredrik\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\fredrik\code\repos\mylittleci\venv\Scripts\tox.exe\__main__.py", line 7, in <module>
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\session\__init__.py", line 44, in cmdline
    main(args)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\session\__init__.py", line 69, in main
    exit_code = session.runcommand()
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\session\__init__.py", line 196, in runcommand
    return self.subcommand_test()
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\session\__init__.py", line 224, in subcommand_test
    run_sequential(self.config, self.venv_dict)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\session\commands\run\sequential.py", line 9, in run_sequential
    if venv.setupenv():
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\venv.py", line 607, in setupenv
    status = self.update(action=action)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox\venv.py", line 264, in update
    self.hook.tox_testenv_create(action=action, venv=self)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\callers.py", line 208, in _multicall
    return outcome.get_result()
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "c:\users\fredrik\code\repos\mylittleci\venv\lib\site-packages\tox_current_env\hooks.py", line 127, in tox_testenv_create
    os.symlink(target, link)
OSError: symbolic link privilege not held
```