### PR TITLE
tests: Use sys.exec_prefix, not sys.executable, to determine the Python run

### DIFF
--- a/tests/fixtures/tox.ini
+++ b/tests/fixtures/tox.ini
@@ -6,4 +6,4 @@ deps =
     six
     py
 commands =
-    python -c 'import os, sys; print(os.path.realpath(sys.executable))'
+    python -c 'import os, sys; print(os.path.realpath(sys.exec_prefix), "is the exec_prefix")'


### PR DESCRIPTION
Virtualenv 20.0 follows symlinks when populating sys.executable,
so we can't use it. (AFAIUI it's done to better handle cases where the
system executable is changed after a virtualenv is created.)
See: https://github.com/pypa/virtualenv/pull/1522

sys.exec_prefix still points to inside the virtualenv, so use that
in the tests to determine what's being run.

Fixes: https://github.com/fedora-python/tox-current-env/issues/26