### PR TITLE
hooks: override list_dependencies_command with dummy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         # but the one downloaded from PyPI isn't and it doesn't work properly.
         "tox>=3.15; python_version >= '3.8'",
         "tox>=3.13; python_version < '3.8'",
+        "importlib_metadata; python_version < '3.8'"
     ],
     python_requires=">=3.6",
     classifiers=[

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -4,6 +4,11 @@ import subprocess
 import sys
 import tox
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
 
 @tox.hookimpl
 def tox_addoption(parser):
@@ -185,3 +190,13 @@ def tox_cleanup(session):
     for venv in session.venv_dict.values():
         if is_current_env_link(venv):
             rm_venv(venv)
+
+
+@tox.hookimpl
+def tox_runenvreport(venv, action):
+    if not venv.envconfig.config.option.current_env:
+        return None
+    return (
+        "{}=={}".format(d.metadata.get("name"), d.version)
+        for d in importlib_metadata.distributions()
+    )

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -194,9 +194,14 @@ def tox_cleanup(session):
 
 @tox.hookimpl
 def tox_runenvreport(venv, action):
-    if not venv.envconfig.config.option.current_env:
+    """Prevent using pip to display installed packages,
+    use importlib.metadata instead, but fallback to default without our flags."""
+    option = venv.envconfig.config.option
+    if not (option.current_env or option.print_deps_only):
         return None
     return (
         "{}=={}".format(d.metadata.get("name"), d.version)
-        for d in importlib_metadata.distributions()
+        for d in sorted(
+            importlib_metadata.distributions(), key=lambda d: d.metadata.get("name")
+        )
     )


### PR DESCRIPTION
This gets rid of the pip dependency, undesirable in some cases.

Signed-off-by: Filipe Laíns <lains@archlinux.org>