### PR TITLE
Deprecate --print-deps-only in favor of --print-deps-to -

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ The ``tox-current-env`` plugin adds two options:
    An attempt to run this with a Python version that doesn't match will fail
    (if ``tox`` is invoked from an Python 3.7 environment, any non 3.7 testenv will fail).
 
-``tox --print-deps-only`` / ``--print-deps-to-file``
+``tox --print-deps-to=FILE``
     Instead of running any ``commands``,
-    simply prints the declared dependencies in ``deps`` to the standard output or specified file.
+    simply prints the declared dependencies in ``deps`` to the specified ``FILE``.
     This is useful for preparing the current environment for the above.
-    ``--print-deps-to-file`` will overwrite the file if it already exists.
+    Use ``-`` for ``FILE`` to print to standard output.
 
 Invoking ``tox`` without any of the above options should behave as regular ``tox`` invocation without this plugin.
 Any deviation from this behavior is considered a bug.
@@ -82,7 +82,7 @@ and ``pip``-installing locally:
 Usage
 -----
 
-When the plugin is installed, use ``tox`` with ``--current-env`` or ``--print-deps-only`` and all the other options as usual. Assuming your ``tox`` is installed on Python 3.7:
+When the plugin is installed, use ``tox`` with ``--current-env`` or ``--print-deps-to`` and all the other options as usual. Assuming your ``tox`` is installed on Python 3.7:
 
 .. code-block:: console
 
@@ -114,7 +114,7 @@ To get list of test dependencies, run:
 
 .. code-block:: console
 
-   $ tox -e py37 --print-deps-only
+   $ tox -e py37 --print-deps-to -
    py37 create: /home/pythonista/projects/holy-grail/tests/.tox/py37
    py37 installed: ...you can see almost anything here...
    py37 run-test-pre: PYTHONHASHSEED='3333333333'
@@ -159,7 +159,7 @@ Don't mix current-env and regular tox runs
 
 Tox caches the virtualenvs it creates, and doesn't distinguish between
 regular virtualenvs and ``--current-env``.
-Don't mix ``tox --current-env`` or ``tox --print-deps-only`` runs
+Don't mix ``tox --current-env`` or ``tox --print-deps-to`` runs
 and regular ``tox`` runs (without the flag).
 If you ever need to do this, use tox's ``--recreate/-r`` flag to clear the cache.
 
@@ -183,7 +183,7 @@ Read `the documentation for passing environment variables to tox
 Other limitations and known bugs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``installed:`` line in the output of ``tox --print-deps-only`` shows irrelevant output
+The ``installed:`` line in the output of ``tox --print-deps-to`` shows irrelevant output
 (based on the content of the real or faked virtual environment).
 
 Regardless of any `Python flags <https://docs.python.org/3/using/cmdline.html>`_ used in the shebang of ``tox``,

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -32,7 +32,6 @@ def tox_addoption(parser):
         "--print-deps-to",
         "--print-deps-to-file",
         action="store",
-        dest="print_deps_to",
         type=argparse.FileType('w'),
         metavar="FILE",
         default=None,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -155,7 +155,7 @@ def test_allenvs_print_deps(print_deps_stdout_arg):
 @pytest.mark.parametrize("toxenv", ["py36", "py37", "py38", "py39"])
 def test_print_deps_to_file(toxenv, tmp_path):
     depspath = tmp_path / "deps"
-    result = tox("-e", toxenv, "--print-deps-to-file", str(depspath))
+    result = tox("-e", toxenv, "--print-deps-to", str(depspath))
     assert depspath.read_text().splitlines() == ["six", "py"]
     expected = textwrap.dedent(
         f"""
@@ -169,7 +169,7 @@ def test_print_deps_to_file(toxenv, tmp_path):
 
 def test_allenvs_print_deps_to_file(tmp_path):
     depspath = tmp_path / "deps"
-    result = tox("--print-deps-to-file", str(depspath))
+    result = tox("--print-deps-to", str(depspath))
     assert depspath.read_text().splitlines() == ["six", "py"] * 4
     expected = textwrap.dedent(
         """
@@ -187,7 +187,7 @@ def test_allenvs_print_deps_to_file(tmp_path):
 def test_allenvs_print_deps_to_existing_file(tmp_path):
     depspath = tmp_path / "deps"
     depspath.write_text("nada")
-    result = tox("--print-deps-to-file", str(depspath))
+    result = tox("--print-deps-to", str(depspath))
     lines = depspath.read_text().splitlines()
     assert "nada" not in lines
     assert "six" in lines
@@ -199,7 +199,7 @@ def test_print_deps_only_print_deps_to_file_are_mutually_exclusive():
         "-e",
         NATIVE_TOXENV,
         "--print-deps-only",
-        "--print-deps-to-file",
+        "--print-deps-to",
         "foobar",
         check=False,
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -351,7 +351,7 @@ def test_print_deps_without_python_command(tmp_path, print_deps_stdout_arg):
     assert result.stdout == expected
 
 
-@pytest.mark.parametrize("flag", [None, "--print-deps-only", "--current-env"])
+@pytest.mark.parametrize("flag", [None, "--print-deps-to=-", "--current-env"])
 def test_noquiet_installed_packages(flag):
     flags = (flag,) if flag else ()
     result = tox("-e", NATIVE_TOXENV, *flags, quiet=False, check=False)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -249,7 +249,7 @@ def test_regular_after_current_is_supported():
     assert "--recreate" not in result.stderr
 
 
-def test_regular_after_killed_current_is_not_supported(print_deps_stdout_arg):
+def test_regular_after_killed_current_is_not_supported():
     # fake broken tox run
     shutil.rmtree(DOT_TOX, ignore_errors=True)
     (DOT_TOX / NATIVE_TOXENV / "bin").mkdir(parents=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,9 +167,10 @@ def test_print_deps_to_file(toxenv, tmp_path):
     assert result.stdout == expected
 
 
-def test_allenvs_print_deps_to_file(tmp_path):
+@pytest.mark.parametrize('option', ('--print-deps-to', '--print-deps-to-file'))
+def test_allenvs_print_deps_to_file(tmp_path, option):
     depspath = tmp_path / "deps"
-    result = tox("--print-deps-to", str(depspath))
+    result = tox(option, str(depspath))
     assert depspath.read_text().splitlines() == ["six", "py"] * 4
     expected = textwrap.dedent(
         """


### PR DESCRIPTION
- Deprecate `--print-deps-only`
- Add `--print-deps-to` as a preferred alias for `--print-deps-to-file`
- Make `--print-deps-to -` mean “print to stdout” (using [`argparse.FileType`](https://docs.python.org/3/library/argparse.html#filetype-objects))

Fixes: https://github.com/fedora-python/tox-current-env/issues/18