### PR TITLE
Print tox minversion+requires with --print-deps-to

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,44 @@ use the ``TOX_TESTENV_PASSENV`` environment variable.
 Read `the documentation for passing environment variables to tox
 <https://tox.readthedocs.io/en/latest/config.html#conf-passenv>`_.
 
+Tox provisioning
+~~~~~~~~~~~~~~~~
+
+The tested projects can specify the
+`minimal tox version <https://tox.readthedocs.io/en/latest/config.html#conf-minversion>`_
+and/or
+`additional requires <https://tox.readthedocs.io/en/latest/config.html#conf-requires>`_
+needed in the environment where ``tox`` is installed.
+Normally, ``tox`` uses *provisioning* when such requirements are not met.
+It creates a virtual environment,
+installs (a newer version of) ``tox`` and the missing packages
+into that environment and proxies all ``tox`` invocations trough that.
+Unfortunately, this is undesired for ``tox-current-env``.
+
+ 1. Starting with ``tox`` 3.23, it is possible to invoke it as
+    ``tox --no-provision`` to prevent the provision entirely.
+    When requirements are missing, ``tox`` fails instead of provisioning.
+    If a path is passed as a value for ``--no-provision``,
+    the requirements will be serialized to the file, as JSON.
+ 2. Starting with ``tox`` 3.22, the requires, if specified, are included in the
+    results of ``tox --print-deps-to``.
+    This only works when they are installed (otherwise see the first point).
+ 3. The minimal tox version, if specified, is included in the results of
+    ``tox --print-deps-to`` (as ``tox >= X.Y.Z``).
+    This only works when the version requirement is satisfied
+    (otherwise see the first point).
+
+With ``tox >= 3.23``, the recommend way to handle this is:
+
+ 1. Run ``tox --no-provision provision.json --print-deps-to=...`` or similar.
+ 2. If the command fails, install requirements from ``provision.json`` to the
+    current environment and try again.
+
+Note that the specified requirements are likely to contain
+`other tox plugins <https://tox.readthedocs.io/en/latest/plugins.html>`_
+and many of them might interfere with ``tox-current-env`` in an undesired way.
+If that is the case, the recommended way is to patch/sed such undesired plugins
+out of the configuration before running ``tox``.
 
 Other limitations and known bugs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="miro@hroncok.cz",
     url="https://github.com/fedora-python/tox-current-env",
     license="MIT",
-    version="0.0.5",
+    version="0.0.6",
     package_dir={"": "src"},
     packages=find_packages("src"),
     entry_points={"tox": ["current-env = tox_current_env.hooks"]},

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -198,10 +198,11 @@ def tox_testenv_install_deps(venv, action):
 
 
 def tox_dependencies(config):
-    """Get dependencies of tox itself, 'minversion' config option"""
-    deps = []
+    """Get dependencies of tox itself, 'minversion' and 'requires' config options"""
+    # config does not have this attribute until tox 3.22:
+    deps = getattr(config, "requires", [])
     if config.minversion is not None:
-        deps.append(f"tox >= {config.minversion}")
+        deps.insert(0, f"tox >= {config.minversion}")
     return deps
 
 

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -199,11 +199,10 @@ def tox_testenv_install_deps(venv, action):
 
 def tox_dependencies(config):
     """Get dependencies of tox itself, 'minversion' and 'requires' config options"""
-    # config does not have this attribute until tox 3.22:
-    deps = getattr(config, "requires", [])
     if config.minversion is not None:
-        deps.insert(0, f"tox >= {config.minversion}")
-    return deps
+        yield f"tox >= {config.minversion}"
+    # config does not have the "requires" attribute until tox 3.22:
+    yield from getattr(config, "requires", [])
 
 
 @tox.hookimpl

--- a/src/tox_current_env/hooks.py
+++ b/src/tox_current_env/hooks.py
@@ -197,6 +197,14 @@ def tox_testenv_install_deps(venv, action):
         return True
 
 
+def tox_dependencies(config):
+    """Get dependencies of tox itself, 'minversion' config option"""
+    deps = []
+    if config.minversion is not None:
+        deps.append(f"tox >= {config.minversion}")
+    return deps
+
+
 @tox.hookimpl
 def tox_runtest(venv, redirect):
     """If --print-deps-to, prints deps instead of running tests.
@@ -208,6 +216,7 @@ def tox_runtest(venv, redirect):
 
     if config.option.print_deps_to:
         print(
+            *tox_dependencies(config),
             *venv.get_resolved_dependencies(),
             sep="\n",
             file=config.option.print_deps_to,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -151,6 +151,24 @@ def test_print_deps(toxenv, print_deps_stdout_arg):
 
 
 @pytest.mark.parametrize("toxenv", ["py36", "py37", "py38", "py39"])
+def test_print_deps_with_tox_minversion(projdir, toxenv, print_deps_stdout_arg):
+    with modify_config(projdir / 'tox.ini') as config:
+        config["tox"]["minversion"] = "3.13"
+    result = tox("-e", toxenv, print_deps_stdout_arg)
+    expected = textwrap.dedent(
+        f"""
+        tox >= 3.13
+        six
+        py
+        ___________________________________ summary ____________________________________
+          {toxenv}: commands succeeded
+          congratulations :)
+        """
+    ).lstrip()
+    assert result.stdout == expected
+
+
+@pytest.mark.parametrize("toxenv", ["py36", "py37", "py38", "py39"])
 def test_print_extras(toxenv, print_extras_stdout_arg):
     result = tox("-e", toxenv, print_extras_stdout_arg)
     expected = textwrap.dedent(


### PR DESCRIPTION
Fixes https://github.com/fedora-python/tox-current-env/issues/39