### PR TITLE
Don't recommend using Python virtual environmetns to isolate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Use an isolated environment
 
 Running (especially third party software's) tests in your system Python environment is dangerous.
 Always use this plugin in an isolated environment,
-such as Python virtualenv, Linux container, virtual machine or chroot.
+such as a Linux container, virtual machine or chroot.
 You have been warned.
 
 Do not rely on virtualenv details


### PR DESCRIPTION
This plugin is designed to escape virtual environments.
Even when tox and tox-current-env are installed in a virtual environment,
the tests are executed in the non-virtualenv Python.

Possibly related to https://github.com/fedora-python/tox-current-env/issues/43