### PR TITLE
Clear PYTHONPATH when executing tox in tests

### DIFF
--- a/tests/fixtures/tox.ini
+++ b/tests/fixtures/tox.ini
@@ -12,3 +12,7 @@ extras =
     full
 commands =
     python -c 'import os, sys; print(os.path.realpath(sys.exec_prefix), "is the exec_prefix")'
+# we explicitly clear this because the inner tox does not need to know
+# see https://github.com/fedora-python/tox-current-env/issues/52
+setenv =
+    PYTHONPATH=


### PR DESCRIPTION
Partial fix for https://github.com/fedora-python/tox-current-env/issues/52