### PR TITLE
CI: Update to actions/checkout@v3 to avoid a deprecation warning

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
   tox_test:
     name: tox test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tox tests
       id: test
       uses: fedora-python/tox-github-action@master


### PR DESCRIPTION
Version 2 uses the node12 runtime.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/