### PR TITLE
Avoid setting the default runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,8 +23,6 @@ jobs:
         # (see https://github.com/fedora-python/tox-github-action/issues/8)
         # Generate it by: tox -l | sed "s/^/- /"
         - py36-tox3
-        - py37-tox3
-        - py37-tox4
         - py38-tox3
         - py38-tox4
         - py39-tox3

--- a/src/tox_current_env/hooks4.py
+++ b/src/tox_current_env/hooks4.py
@@ -93,10 +93,6 @@ def tox_add_core_config(core_conf, state):
         opt.default_runner = "print-env"
         return
 
-    # No options used - switch back to the standard runner
-    # Workaround for: https://github.com/tox-dev/tox/issues/2264
-    opt.default_runner = "virtualenv"
-
 
 @impl
 def tox_add_env_config(env_conf, state):


### PR DESCRIPTION
Setting the default runner to tox's default when `--current-env` is not used can override another plugin like `tox-uv` which wants to change the default runner. According to [this comment](https://github.com/fedora-python/tox-current-env/pull/42#discussion_r1048595612) the issue that led to the need to set the default runner has been addressed and that appears to be confirmed by testing.