### PR TITLE
Move extras option creation to register_config, do it after tox itself

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,8 +23,6 @@ jobs:
         # (see https://github.com/fedora-python/tox-github-action/issues/8)
         # Generate it by: tox -l | sed "s/^/- /"
         - py36-tox3
-        - py38-tox3
-        - py38-tox4
         - py39-tox3
         - py39-tox4
         - py310-tox3
@@ -36,5 +34,6 @@ jobs:
         - py313-tox3
         - py313-tox4
         - py314-tox4
+        - py315-tox4
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="miro@hroncok.cz",
     url="https://github.com/fedora-python/tox-current-env",
     license="MIT",
-    version="0.0.16",
+    version="0.0.17",
     package_dir={"": "src"},
     packages=find_packages("src"),
     entry_points={"tox": ["current-env = tox_current_env.hooks"]},

--- a/src/tox_current_env/hooks4.py
+++ b/src/tox_current_env/hooks4.py
@@ -241,14 +241,15 @@ class CurrentEnv(PythonRun):
 
 
 class PrintEnv(CurrentEnv):
-    def __init__(self, create_args):
-        super().__init__(create_args)
+    def register_config(self):
+        super().register_config()
 
         if self.options.print_extras_to:
             if "extras" not in self.conf:
                 # Unfortunately, if there is skipsdist/no_package or skip_install
                 # in the config, this section is not parsed at all so we have to
                 # do it here manually to be able to read its content.
+                # This is no longer true on tox 4.44+, but the if above guards it.
                 self.conf.add_config(
                     keys=["extras"],
                     of_type=Set[str],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 # This information is repeated in .github/workflows/main.yaml
 # (see https://github.com/fedora-python/tox-github-action/issues/8)
-envlist = py36-tox3,{py37,py38,py39,py310,py311,py312,py313}-tox{3,4},py314-tox4
+envlist = py36-tox3,{py39,py310,py311,py312,py313}-tox{3,4},{py314,py15}-tox4
 
 [testenv]
 extras =


### PR DESCRIPTION
In tox < 4.44 we still need to do it.

In tox 4.44+ apparently we don't need it, but if we check
    if "extras" not in self.conf
*after* super().register_config(), we are good.

Note that the register_config() method even sounds like a better place to, well... register a config option. It has been around since the beginning of tox 4. Ref: https://github.com/tox-dev/tox/commit/741362fb52

Fixes https://github.com/fedora-python/tox-current-env/issues/90